### PR TITLE
Add PAF Aliases, OpenAPI Spec Reorg, Reverse Geo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# [3.0.0-beta.3](https://github.com/ideal-postcodes/openapi/compare/3.0.0-beta.2...3.0.0-beta.3) (2022-06-02)
+
+
+### Features
+
+* **GBR:** Add reverse geocoding parameters ([3d5d273](https://github.com/ideal-postcodes/openapi/commit/3d5d2730404253924159847d3706d156b1bad4f2))
+
 # [3.0.0-beta.2](https://github.com/ideal-postcodes/openapi/compare/3.0.0-beta.1...3.0.0-beta.2) (2022-06-01)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# [3.0.0-beta.2](https://github.com/ideal-postcodes/openapi/compare/3.0.0-beta.1...3.0.0-beta.2) (2022-06-01)
+
+
+### Features
+
+* **PAF Alias:** Add PAF Alias ([8b42b86](https://github.com/ideal-postcodes/openapi/commit/8b42b86c4ec91aa9364ec8fc424437596575f324))
+
 # [3.0.0-beta.1](https://github.com/ideal-postcodes/openapi/compare/2.1.1...3.0.0-beta.1) (2022-05-04)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,17 @@
+# [3.0.0-beta.1](https://github.com/ideal-postcodes/openapi/compare/2.1.1...3.0.0-beta.1) (2022-05-04)
+
+
+### Features
+
+* **3.0.0:** API & Dataset Updates ([883abc7](https://github.com/ideal-postcodes/openapi/commit/883abc76d119f05310aca8f662c7b0221c8b3ceb))
+
+
+### BREAKING CHANGES
+
+* **3.0.0:** - UK Address Suggestion formats for PAF, MR, NYB and PAFW have been
+  merged into one suggestion type for the UK
+- Rename GlobalAddressSuggestion to AddressSuggestion
+
 ## [2.1.1](https://github.com/ideal-postcodes/openapi/compare/2.1.0...2.1.1) (2022-05-03)
 
 

--- a/dist/openapi.json
+++ b/dist/openapi.json
@@ -2677,13 +2677,42 @@
           }
         }
       },
+      "Context": {
+        "title": "Context",
+        "type": "string",
+        "enum": [
+          "GBR",
+          "USA"
+        ],
+        "description": "Limits search results within a geographical boundary or country."
+      },
+      "NoContext": {
+        "title": "No Context Provided",
+        "type": "string",
+        "enum": [
+          ""
+        ],
+        "description": "Empty string if no context is provided or key check has failed"
+      },
       "ApiKey": {
         "title": "Key",
         "type": "object",
         "required": [
-          "available"
+          "available",
+          "context"
         ],
         "properties": {
+          "context": {
+            "description": "Returns current context if it is in the list of available contexts for this key.\n",
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/Context"
+              },
+              {
+                "$ref": "#/components/schemas/NoContext"
+              }
+            ]
+          },
           "available": {
             "description": "Determines whether the key can be used by the requesting agent. \n\nReturns false if one of the following conditions are met:\n  - Key has no lookups remaining\n  - Daily limit has been reached on the key\n  - Daily individual limit has been reached\n  - Key is not being used via an authorised URL\n  - (Sublicensed key only) Key has a valid licensee attached\n  - (Sublicensed key only) Key is not being used via an authorised URL specified by licensee\n",
             "type": "boolean",
@@ -3041,15 +3070,6 @@
           }
         }
       },
-      "Context": {
-        "title": "Context",
-        "type": "string",
-        "enum": [
-          "gbr",
-          "usa"
-        ],
-        "description": "Limits search results within a geographical boundary or country."
-      },
       "LimitParam": {
         "title": "Limit",
         "description": "Specifies the maximum number of suggestions to retrieve.\n\nBy default the limit is 10, unless a postcode is queried (then all addresses at that postcode will be returned). Limit can be shortened to `l=`\n",
@@ -3309,6 +3329,26 @@
           }
         ]
       },
+      "PafAliasAddress": {
+        "title": "PAF Alias Address",
+        "description": "PAF Aliases addresses are alternate ways to present an address already found on PAF.\n\nAlias data is information the public chooses to use when addressing mail, but which isn’t actually required for delivery purposes.  The Alias data contains records of alternative address details that are included in the address but not necessarily needed for delivery purposes.\n",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/PafAddress"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "dataset": {
+                "$ref": "#/components/schemas/Dataset",
+                "enum": [
+                  "pafa"
+                ]
+              }
+            }
+          }
+        ]
+      },
       "GbrGlobalAddress": {
         "title": "Global Address",
         "description": "Global (non-UK) address in the UK address format",
@@ -3559,6 +3599,9 @@
               },
               {
                 "$ref": "#/components/schemas/WelshPafAddress"
+              },
+              {
+                "$ref": "#/components/schemas/PafAliasAddress"
               },
               {
                 "$ref": "#/components/schemas/NybAddress"
@@ -4409,6 +4452,9 @@
                     },
                     {
                       "$ref": "#/components/schemas/WelshPafAddress"
+                    },
+                    {
+                      "$ref": "#/components/schemas/PafAliasAddress"
                     }
                   ]
                 }

--- a/dist/openapi.json
+++ b/dist/openapi.json
@@ -1,14 +1,14 @@
 {
   "openapi": "3.0.3",
   "info": {
-    "version": "2.1.1",
+    "version": "3.0.0",
     "license": {
       "name": "AGPLv3",
       "url": "https://opensource.org/licenses/AGPL-3.0"
     },
     "title": "API Reference - Ideal Postcodes",
     "termsOfService": "https://terms.ideal-postcodes.co.uk",
-    "description": "# Getting Started\n\n## Overview\n\n### Access\n\nAll API methods are either a `GET`, `POST` or `OPTIONS` request.\n\nThe API communicates over both HTTPS and plain HTTP using IPv4 and IPv6.\n\nWe recommend using HTTPS only although HTTP is available.\n\nWe use appropriate HTTP status codes where possible to indicate the request status.\n\n### Rate Limiting\n\nEach IP address is rate limited at 30 requests per second. Tripping the rate limit will result in a 503 response.\n\nThe autocomplete API also has an additional rate limit.\n\nIf you expect to breach the limit please contact us and we can move you to an endpoint with a higher limit.\n\n### JSONP\n\n[JSONP](http://en.wikipedia.org/wiki/JSONP) requests are supported. Include a `callback=` in your request as a query parameter. Your results return wrapped in a function designated by your request.\n\n## Authentication\n\nMost requests require an **API key** for authentication. Authenticate by passing an `api_key` as part of the query string. For example:\n\n```\napi.ideal-postcodes.co.uk/v1/autocomplete/addresses?api_key=iddqd&q=parkside\n```\n\nAlternatively, authentication can be transmitted via the `Authorization` header using the following scheme:\n\n```\nAuthorization: IDEALPOSTCODES api_key=\"iddqd\" [other_key=\"foo\"]\n```\n\n## Versioning\n\nThis API is versioned with a simple prefix in the URL. The current version is `/v1/`. We will maintain backwards-compatibility by releasing breaking changes under a new version.\n\nPlease note that the following changes are backwards-compatible:\n\n- Adding new properties to existing API responses\n- Adding new API endpoints\n- Adding new optional request parameters to existing API endpoints\n- Changing the order of properties in existing API responses\n- Changing the autocomplete address suggestion format\n\n## Error Handling\n\nA successful lookup is accompanied with a HTTP status code of 200 and a response code of 2000 (found in the body).\n\nAn error has occurred if the HTTP status code is not 200. Errors can range from a benign 404 (resource not found) to more urgent errors (your API Key ran out of credit, failed authentication, etc).\n\n## Testing\n\nEach new account comes with a free test balance. Contact us if you need more for testing and integration.\n\n### Community Key\n\nOur documentation and demos make heavy use of our community key `iddqd`. This allows for convenient access for trialing the API.\n\nMany restrictions on this key are relaxed to allow developers make test requests. This key has a limit of 15 lookups per IP address per day as well as a daily usage cap. If you hit any limit restrictions, you can continue testing the API by creating a key of your own and using our free test methods.\n\nPlease be kind with the community key. We're trusting everyone to use it responsibly so that other developers may trial the API. Thank you!\n\n## Metadata\n\nRequests that affect your balance may be annotated with arbitrary metadata. This data is stored along with your lookup history and can be queried at a later date via the API or the dashboard. We call the ability to label your requests [tagging](https://docs.ideal-postcodes.co.uk/docs/guides/tags).\n\n# Response Codes\n\nThe API returns two indicators to help you to determine the status of each HTTP request.\n\nThe first is the **HTTP Status**, which is found in the status-line of all HTTP requests. The API will return status codes that adhere to HTTP /1.1 Specifications wherever possible.\n\n`2XX` status codes indicates success while `4XX` and `5XX` indicate client and server errors respectively.\n\nThe second is the **API response code**, which can be found in the `code` property of the response body. This code will provide a more specific reason if a failure has occurred and can point you in the right direction when debugging.\n\nPlease use the glossary of code numbers and HTTP status codes below when debugging your requests.\n\n## 200 Request Success\n\n| HTTP Code | API Code | Description                                  |\n| --------- | -------- | -------------------------------------------- |\n| 200       | 2000     | Success. Request was completed successfully. |\n\n## 400 Bad Request\n\nThe request could not be understood due to some input error.\n\n| HTTP Code | API Code | Description                                                                                                                           |\n| --------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------- |\n| 400       | 4000     | Invalid syntax submitted. Some part of your request was malformed or did not match our specifications.                                |\n| 400       | 4001     | Validation failed on your submitted data. Some of the data you provided did not meet our validation requirements, e.g. string length. |\n| 400       | 4005     | Invalid start date. Please ensure start dates are provided as a UTC Timestamp in milliseconds.                                        |\n| 400       | 4006     | Invalid end date. Please ensure end dates are provided as a UTC Timestamp in milliseconds.                                            |\n| 400       | 4007     | Invalid date range. Check if your start and end dates are in the right order.                                                         |\n| 400       | 4008     | Invalid date range. Check that your date range is 90 days or less.                                                                    |\n| 400       | 4009     | Too many tags. Please specify no more than 3 tags to query.                                                                           |\n\n## 401 Unauthorised\n\nAuthorization credentials are not valid.\n\n| HTTP Code | API Code | Description                                                                                                                                                        |\n| --------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ |\n| 401       | 4010     | Invalid Key. The `api_key` you provided is not valid.                                                                                                              |\n| 401       | 4011     | Requesting URL not on whitelist. The cross domain request is not coming from a whitelisted URL. You can update or disable your allowed URLs via your Key settings. |\n| 401       | 4012     | Failed user authentication. Invalid `user_token` presented.                                                                                                        |\n| 401       | 4013     | Licensee Key is required. Sublicensed keys require you need to present licensee credentials via the `licensee` parameter.                                          |\n\n## 402 Request Failed\n\nYour request is well-formed but are not able to complete your request for another reason.\n\n| HTTP Code | API Code | Description                                                                                                                                                                                                                                                        |\n| --------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |\n| 402       | 4020     | Key balance depleted. You're out of lookups on your API Key.                                                                                                                                                                                                       |\n| 402       | 4021     | Limit reached. One of your lookup limits has been breached for today. This could either be your total daily limit on your key or the individual IP limit. You can either wait for for the limit to reset (after a day) or manually disable or increase your limit. |\n\n## 404 Resource Not Found\n\nThe resource you requested does not exist.\n\n| HTTP Code | API Code | Description                                                                                   |\n| --------- | -------- | --------------------------------------------------------------------------------------------- |\n| 404       | 4040     | Postcode not found. The postcode you have submitted does not exist.                           |\n| 404       | 4041     | User not found. Your user could not be identified given the credentials you presented.        |\n| 404       | 4042     | Key not found. Your key could not be identified given the credentials you presented.          |\n| 404       | 4044     | No UDPRN found. No address is associated with the UDPRN queried                               |\n| 404       | 4045     | No licensee found. Your licensee could not be identified given the credentials you presented. |\n| 404       | 4046     | No UMPRN found. No Multiple Residence premise is associated with the UMPRN queried.           |\n\n## 500 Server Error\n\nA error occurred on our server.\n\n| HTTP Code | API Code | Description                                                                                                                                                        |\n| --------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ |\n| 500       | 5000     | An error occurred on our end. These errors are logged and queued so we can understand what went wrong. However, if you need speedy resolution please email support |\n| 500       | 5001     | Akin to 5000.                                                                                                                                                      |\n| 500       | 5002     | The server took too long to process on our end, so we aborted the request. You may retry the request.                                                              |\n",
+    "description": "# Getting Started\n\n## Overview\n\n### Access\n\nAll API methods are either a `GET`, `POST` or `OPTIONS` request.\n\nThe API communicates over both HTTPS and plain HTTP using IPv4 and IPv6.\n\nWe recommend using HTTPS only although HTTP is available.\n\nWe use appropriate HTTP status codes where possible to indicate the request status.\n\n### Rate Limiting\n\nEach IP address is rate limited at 30 requests per second. Tripping the rate limit will result in a 503 response.\n\nThe autocomplete API also has an additional rate limit.\n\nIf you expect to breach the limit please contact us and we can move you to an endpoint with a higher limit.\n\n### JSONP\n\n[JSONP](http://en.wikipedia.org/wiki/JSONP) requests are supported. Include a `callback=` in your request as a query parameter. Your results return wrapped in a function designated by your request.\n\n## Authentication\n\nMost requests require an **API key** for authentication. Authenticate by passing an `api_key` as part of the query string. For example:\n\n```\napi.ideal-postcodes.co.uk/v1/autocomplete/addresses?api_key=iddqd&q=parkside\n```\n\nAlternatively, authentication can be transmitted via the `Authorization` header using the following scheme:\n\n```\nAuthorization: api_key=\"iddqd\" [other_key=\"foo\"]\n```\n\n## Versioning\n\nThis API is versioned with a simple prefix in the URL. The current version is `/v1/`. We will maintain backwards-compatibility by releasing breaking changes under a new version.\n\nPlease note that the following changes are backwards-compatible:\n\n- Adding new properties to existing API responses\n- Adding new API endpoints\n- Adding new optional request parameters to existing API endpoints\n- Changing the order of properties in existing API responses\n- Changing the autocomplete address suggestion format\n\n## Error Handling\n\nA successful lookup is accompanied with a HTTP status code of 200 and a response code of 2000 (found in the body).\n\nAn error has occurred if the HTTP status code is not 200. Errors can range from a benign 404 (resource not found) to more urgent errors (your API Key ran out of credit, failed authentication, etc).\n\n## Testing\n\nEach new account comes with a free test balance. Contact us if you need more for testing and integration.\n\n### Community Key\n\nOur documentation and demos make heavy use of our community key `iddqd`. This allows for convenient access for trialing the API.\n\nMany restrictions on this key are relaxed to allow developers make test requests. This key has a limit of 15 lookups per IP address per day as well as a daily usage cap. If you hit any limit restrictions, you can continue testing the API by creating a key of your own and using our free test methods.\n\nPlease be kind with the community key. We're trusting everyone to use it responsibly so that other developers may trial the API. Thank you!\n\n## Metadata\n\nRequests that affect your balance may be annotated with arbitrary metadata. This data is stored along with your lookup history and can be queried at a later date via the API or the dashboard. We call the ability to label your requests [tagging](https://docs.ideal-postcodes.co.uk/docs/guides/tags).\n\n# Response Codes\n\nThe API returns two indicators to help you to determine the status of each HTTP request.\n\nThe first is the **HTTP Status**, which is found in the status-line of all HTTP requests. The API will return status codes that adhere to HTTP /1.1 Specifications wherever possible.\n\n`2XX` status codes indicates success while `4XX` and `5XX` indicate client and server errors respectively.\n\nThe second is the **API response code**, which can be found in the `code` property of the response body. This code will provide a more specific reason if a failure has occurred and can point you in the right direction when debugging.\n\nPlease use the glossary of code numbers and HTTP status codes below when debugging your requests.\n\n## 200 Request Success\n\n| HTTP Code | API Code | Description                                  |\n| --------- | -------- | -------------------------------------------- |\n| 200       | 2000     | Success. Request was completed successfully. |\n\n## 400 Bad Request\n\nThe request could not be understood due to some input error.\n\n| HTTP Code | API Code | Description                                                                                                                           |\n| --------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------- |\n| 400       | 4000     | Invalid syntax submitted. Some part of your request was malformed or did not match our specifications.                                |\n| 400       | 4001     | Validation failed on your submitted data. Some of the data you provided did not meet our validation requirements, e.g. string length. |\n| 400       | 4005     | Invalid start date. Please ensure start dates are provided as a UTC Timestamp in milliseconds.                                        |\n| 400       | 4006     | Invalid end date. Please ensure end dates are provided as a UTC Timestamp in milliseconds.                                            |\n| 400       | 4007     | Invalid date range. Check if your start and end dates are in the right order.                                                         |\n| 400       | 4008     | Invalid date range. Check that your date range is 90 days or less.                                                                    |\n| 400       | 4009     | Too many tags. Please specify no more than 3 tags to query.                                                                           |\n\n## 401 Unauthorised\n\nAuthorization credentials are not valid.\n\n| HTTP Code | API Code | Description                                                                                                                                                        |\n| --------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ |\n| 401       | 4010     | Invalid Key. The `api_key` you provided is not valid.                                                                                                              |\n| 401       | 4011     | Requesting URL not on whitelist. The cross domain request is not coming from a whitelisted URL. You can update or disable your allowed URLs via your Key settings. |\n| 401       | 4012     | Failed user authentication. Invalid `user_token` presented.                                                                                                        |\n| 401       | 4013     | Licensee Key is required. Sublicensed keys require you need to present licensee credentials via the `licensee` parameter.                                          |\n\n## 402 Request Failed\n\nYour request is well-formed but are not able to complete your request for another reason.\n\n| HTTP Code | API Code | Description                                                                                                                                                                                                                                                        |\n| --------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |\n| 402       | 4020     | Key balance depleted. You're out of lookups on your API Key.                                                                                                                                                                                                       |\n| 402       | 4021     | Limit reached. One of your lookup limits has been breached for today. This could either be your total daily limit on your key or the individual IP limit. You can either wait for for the limit to reset (after a day) or manually disable or increase your limit. |\n\n## 404 Resource Not Found\n\nThe resource you requested does not exist.\n\n| HTTP Code | API Code | Description                                                                                   |\n| --------- | -------- | --------------------------------------------------------------------------------------------- |\n| 404       | 4040     | Postcode not found. The postcode you have submitted does not exist.                           |\n| 404       | 4041     | User not found. Your user could not be identified given the credentials you presented.        |\n| 404       | 4042     | Key not found. Your key could not be identified given the credentials you presented.          |\n| 404       | 4044     | No UDPRN found. No address is associated with the UDPRN queried                               |\n| 404       | 4045     | No licensee found. Your licensee could not be identified given the credentials you presented. |\n| 404       | 4046     | No UMPRN found. No Multiple Residence premise is associated with the UMPRN queried.           |\n\n## 500 Server Error\n\nA error occurred on our server.\n\n| HTTP Code | API Code | Description                                                                                                                                                        |\n| --------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ |\n| 500       | 5000     | An error occurred on our end. These errors are logged and queued so we can understand what went wrong. However, if you need speedy resolution please email support |\n| 500       | 5001     | Akin to 5000.                                                                                                                                                      |\n| 500       | 5002     | The server took too long to process on our end, so we aborted the request. You may retry the request.                                                              |\n",
     "contact": {
       "email": "support@ideal-postcodes.co.uk",
       "name": "Support",
@@ -48,19 +48,19 @@
       "description": "The Config resource allows users to assign serialised configuration data to API Keys. The payloads assigned to a Config object can later be retrieved to dynamically configure your integration.\n\nUseful if you need to configure your integration remotely rather than editing code in situ.\n"
     },
     {
+      "name": "suggestion",
+      "x-displayName": "Address Suggestion",
+      "description": "Address Suggestions are simple, human readable representations of an address. This format is sufficient tfor a user to determine an address match in an address autocomplete interface. A second request must be made to the API to gather fully validated address.\n\nSee our Address Search APIs for more information on address autocompletion.\n\n<SchemaDefinition schemaRef=\"#/components/schemas/AddressSuggestion\" />\n"
+    },
+    {
       "name": "usps_address",
       "x-displayName": "US Address",
-      "description": "<SchemaDefinition schemaRef=\"#/components/schemas/UspsAddress\" />\n"
+      "description": "Standard US Address format as reported by USPS.\n\n<SchemaDefinition schemaRef=\"#/components/schemas/UspsAddress\" />\n"
     },
     {
       "name": "uk_address",
       "x-displayName": "UK Address",
-      "description": "<SchemaDefinition schemaRef=\"#/components/schemas/PafAddress\" />\n"
-    },
-    {
-      "name": "suggestion",
-      "x-displayName": "Global Address Suggestion",
-      "description": "<SchemaDefinition schemaRef=\"#/components/schemas/GlobalAddressSuggestion\" />\n"
+      "description": "Standard UK Address format as reported by Royal Mail's Postcode Address File (PAF). PAF is the most complete and up-to-date address database in the UK.\n\n<SchemaDefinition schemaRef=\"#/components/schemas/PafAddress\" />\n"
     }
   ],
   "x-tagGroups": [
@@ -113,7 +113,6 @@
             "name": "api_key",
             "in": "query",
             "style": "form",
-            "required": true,
             "explode": false,
             "schema": {
               "$ref": "#/components/schemas/ApiKeyParam"
@@ -199,7 +198,6 @@
           {
             "name": "api_key",
             "in": "query",
-            "required": true,
             "style": "form",
             "explode": false,
             "schema": {
@@ -275,7 +273,6 @@
           },
           {
             "name": "api_key",
-            "required": true,
             "in": "query",
             "style": "form",
             "explode": false,
@@ -397,7 +394,6 @@
             "name": "user_token",
             "in": "query",
             "style": "form",
-            "required": true,
             "explode": false,
             "schema": {
               "$ref": "#/components/schemas/UserTokenParam"
@@ -598,14 +594,13 @@
           "Address Search"
         ],
         "summary": "Find Address",
-        "description": "The address autocomplete API returns a list of address suggestions that match the query ordered by relevance score.\n\nThis API can be used to power realtime address finders, also known as address autofill or address autocomplete.\n\nIf you wish to quickly add address autocompletion to your address forms, see [Address Finder](/address-finder) and [associated demos](/address-finder-demo).\n\n## Implementing Address Autocomplete\n\nRetrieving addresses using Address Autocomplete is a 2 step process.\n\n1. Retrieve partial address suggestions via `/autocomplete/addresses`\n2. Retrieve the entire address by following the URL provided by the suggestion\n\nStep 2 will decrement your lookup balance.\n\nPlease note, this API is not intended to be a free standalone resource.\n\n## Filters\n\nYou can strictly narrow your result by adding filters to your querystring which correspond with an address attribute.\n\nFor instance, you can restrict to postcode `SW1A 2AA` by appending `postcode=sw1a2aa`.\n\nIf a filter term is invalid, e.g. `postcode=SW1A2AAA`, then an empty result set is returned and no lookup is incurred.\n\nYou can also scope using multiple terms for the same filter with a comma separated list of terms. E.g. Restrict results to E1, E2 and E3 outward codes: `postcode_outward=e1,e2,e3`. Multiple terms are <code>OR</code>'ed, i.e. the matching result sets are combined.\n\nAll filters can accept multiple terms unless stated otherwise below.\n\nMultiple filters can also be combined. E.g. Restrict results to small user organisations in the N postcode area: `su_organisation_indicator=Y&postcode_area=n`. Multiple filters are <code>AND</code>'ed, i.e. each additional filter narrows the result set.\n\nA maximum of **10** terms are allowed across all filters.\n\n## Biases\n\nYou can boost certain addresses results that correspond with a certain address attribute. All bias searches are prefixed with `bias_`.\n\nBiased searches, unlike filtered searches, also allow unmatched addresses to appear. These will rank lower.\n\nFor instance, can boost addresses with postcode areas `SW` and `SE` by appending `bias_postcode_area=SW,SE`.\n\nNo bias effect applies to bias terms that are invalid.\ne.g. `bias_postcode=SW1A2AAA`\n\nYou may scope using multiple terms for the same bias with a comma separated list of terms. E.g. Restrict results to `E1`, `E2` and `E3` outward codes: <code>bias_postcode_outward=e1,e2,e3</code>.\n\nAll biases can accept multiple terms unless stated otherwise below.\n\nA combined maximum of **5** terms are allowed across all biases.\n\n## Suggestion Format\n\nThe suggestion format is prone to change over time. Attempts to parse the suggestion may result in your integration breaking. Instead use the suggestion as-is.\n\n## Rate Limiting\n\nYou can make up to 3000 requests to the autocomplete API within a 5 minute span. The HTTP Header contains information on your current rate limit.\n\n| Header                  | Description                                                                            |\n| ----------------------- | -------------------------------------------------------------------------------------- |\n| `X-RateLimit-Limit`     | The maximum number of requests that can be made in 5 minutes                           |\n| `X-RateLimit-Remaining` | The remaining requests within the current rate limit window                            |\n| `X-RateLimit-Reset`     | The time when the rate limit window resets in Unix Time (seconds) or UTC Epoch seconds |\n\n## Pricing\n\nThis API currently does not affect your balance. However, resolving a suggestion into a full address requires a paid request.\n\nPlease note, this API is not intended as a standalone free resource. Integrations that consistently make autocomplete requests without a paid request to resolve an address may be disrupted via tightened rate limits. Continued misuse will result in account suspension.\n",
+        "description": "The address autocomplete API returns a list of address suggestions that match the query ordered by relevance.\n\nThis API can be used to power realtime address finders, also known as address autofill or address autocomplete.\n\nConsider using our Address Autocomplete JavaScript libraries to add address lookup to a form in moments.\n\n## Implementing Address Autocomplete\n\nRapid address autocompletion using our Address Autocomplete API is a 2 step process.\n\n1. Retrieve partial address suggestions via `/autocomplete/addresses`\n2. Retrieve the entire address with the ID provided in the suggestion\n\nStep 2 will decrement your lookup balance.\n\nPlease note, this API is not intended to be a free standalone resource.\n\n## Filters\n\nYou can strictly narrow your result by adding filters to your querystring. For instance, you can restrict to postcode `SW1A 2AA` by appending `postcode=sw1a2aa`.\n\nIf a filter term is invalid, e.g. `postcode=SW1A2AAA`, then an empty result set is returned and no lookup is incurred.\n\nYou can also scope using multiple terms for the same filter with a comma separated list of terms. E.g. Restrict results to E1, E2 and E3 outward codes: `postcode_outward=e1,e2,e3`. Multiple terms are `OR`'ed, i.e. the matching result sets are combined.\n\nAll filters can accept multiple terms unless stated otherwise below.\n\nFilters can also be combined. E.g. Restrict results to small user organisations in the N postcode area: `su_organisation_indicator=Y&postcode_area=n`. Multiple filters are `AND`'ed, i.e. each additional filter narrows the result set.\n\nA maximum of **10** terms are allowed across all filters.\n\n## Biases\n\nYou can boost certain addresses results that match specific address criteria. All bias searches are prefixed with `bias_`.\n\nBiasing (unlike filtering) also allow unmatched addresses to appear with lower precedence.\n\nFor instance, can boost addresses with postcode areas `SW` and `SE` by appending `bias_postcode_area=SW,SE`.\n\nNo bias effect applies to bias terms that are invalid. e.g. `bias_postcode=SW1A2AAA`\n\nYou may scope using multiple terms for the same bias with a comma separated list of terms. E.g. Restrict results to `E1`, `E2` and `E3` outward codes: <code>bias_postcode_outward=e1,e2,e3</code>.\n\nAll biases can accept multiple terms unless stated otherwise below.\n\nA combined maximum of **5** terms are allowed across all biases.\n\n## Suggestion Format\n\nThe suggestion format is prone to change over time. Attempts to parse the suggestion may result in your integration breaking. Instead use the suggestion as-is.\n\n## Rate Limiting\n\nYou can make up to 3000 requests to the autocomplete API within a 5 minute span. The HTTP Header contains information on your current rate limit.\n\n| Header                  | Description                                                                            |\n| ----------------------- | -------------------------------------------------------------------------------------- |\n| `X-RateLimit-Limit`     | The maximum number of requests that can be made in 5 minutes                           |\n| `X-RateLimit-Remaining` | The remaining requests within the current rate limit window                            |\n| `X-RateLimit-Reset`     | The time when the rate limit window resets in Unix Time (seconds) or UTC Epoch seconds |\n\n## Pricing\n\nThis API currently does not affect your balance. However, resolving a suggestion into a full address requires a paid request.\n\nPlease note, this API is not intended as a standalone free resource. Integrations that consistently make autocomplete requests without a paid request to resolve an address may be disrupted via tightened rate limits. Continued misuse will result in account suspension.\n",
         "operationId": "AddressAutocomplete",
         "parameters": [
           {
             "name": "api_key",
             "in": "query",
             "style": "form",
-            "required": true,
             "explode": false,
             "schema": {
               "$ref": "#/components/schemas/ApiKeyParam"
@@ -884,7 +879,6 @@
           {
             "name": "api_key",
             "in": "query",
-            "required": true,
             "style": "form",
             "explode": false,
             "schema": {
@@ -952,7 +946,6 @@
           {
             "name": "api_key",
             "in": "query",
-            "required": true,
             "style": "form",
             "explode": false,
             "schema": {
@@ -1275,7 +1268,6 @@
           {
             "name": "user_token",
             "in": "query",
-            "required": true,
             "style": "form",
             "explode": false,
             "schema": {
@@ -1337,7 +1329,6 @@
           {
             "name": "user_token",
             "in": "query",
-            "required": true,
             "style": "form",
             "explode": false,
             "schema": {
@@ -1401,7 +1392,6 @@
           {
             "name": "user_token",
             "in": "query",
-            "required": true,
             "style": "form",
             "explode": false,
             "schema": {
@@ -1454,7 +1444,6 @@
           {
             "name": "user_token",
             "in": "query",
-            "required": true,
             "style": "form",
             "explode": false,
             "schema": {
@@ -1541,7 +1530,6 @@
           {
             "name": "user_token",
             "in": "query",
-            "required": true,
             "style": "form",
             "explode": false,
             "schema": {
@@ -1595,7 +1583,6 @@
           {
             "name": "user_token",
             "in": "query",
-            "required": true,
             "style": "form",
             "explode": false,
             "schema": {
@@ -1657,7 +1644,6 @@
           {
             "name": "user_token",
             "in": "query",
-            "required": true,
             "style": "form",
             "explode": false,
             "schema": {
@@ -1804,7 +1790,6 @@
           {
             "name": "user_token",
             "in": "query",
-            "required": true,
             "style": "form",
             "explode": false,
             "schema": {
@@ -1921,7 +1906,6 @@
           {
             "name": "user_token",
             "in": "query",
-            "required": true,
             "style": "form",
             "explode": false,
             "schema": {
@@ -2121,10 +2105,7 @@
         "oneOf": [
           {
             "type": "string",
-            "description": "If premise is not multiple occupancy, this will be an empty string",
-            "enum": [
-              ""
-            ]
+            "description": "If premise is not multiple occupancy, this will be an empty string"
           },
           {
             "type": "number",
@@ -2230,10 +2211,7 @@
         "oneOf": [
           {
             "type": "string",
-            "description": "Empty string `\"\"` if not available",
-            "enum": [
-              ""
-            ]
+            "description": "Empty string `\"\"` if not available"
           },
           {
             "type": "number",
@@ -2250,10 +2228,7 @@
         "oneOf": [
           {
             "type": "string",
-            "description": "Empty string `\"\"` if not available",
-            "enum": [
-              ""
-            ]
+            "description": "Empty string `\"\"` if not available"
           },
           {
             "type": "number",
@@ -2270,10 +2245,7 @@
         "oneOf": [
           {
             "type": "string",
-            "description": "Empty string `\"\"` if not available",
-            "enum": [
-              ""
-            ]
+            "description": "Empty string `\"\"` if not available"
           },
           {
             "type": "number",
@@ -2290,10 +2262,7 @@
         "oneOf": [
           {
             "type": "string",
-            "description": "Empty string `\"\"` if not available",
-            "enum": [
-              ""
-            ]
+            "description": "Empty string `\"\"` if not available"
           },
           {
             "type": "number",
@@ -2322,6 +2291,7 @@
         "enum": [
           "paf",
           "pafw",
+          "pafa",
           "mr",
           "nyb",
           "usps"
@@ -3203,110 +3173,8 @@
         "description": "Biases search based on approximate geolocation of IP address.\nSet `bias_ip=true` to enable.",
         "example": "bias_ip=true"
       },
-      "PafSuggestion": {
-        "title": "UK Postcode Address File Address Autocompletion Hit",
-        "description": "Represents an address suggestion from the UK Postcode Address File.",
-        "type": "object",
-        "required": [
-          "id",
-          "suggestion",
-          "udprn",
-          "urls"
-        ],
-        "properties": {
-          "id": {
-            "$ref": "#/components/schemas/ID"
-          },
-          "suggestion": {
-            "type": "string",
-            "description": "Address suggestion for your given query.",
-            "example": "Flat 6, 12 Roskear, Camborne, TR14"
-          },
-          "udprn": {
-            "$ref": "#/components/schemas/UDPRN"
-          },
-          "urls": {
-            "required": [
-              "udprn"
-            ],
-            "type": "object",
-            "properties": {
-              "udprn": {
-                "type": "string",
-                "description": "URL to retrieve the entire details for a given address suggestion by the UDPRN",
-                "example": "/v1/udprn/50985827"
-              }
-            }
-          }
-        }
-      },
-      "MrSuggestion": {
-        "title": "Multiple Residence Address Autocompletion Hit",
-        "type": "object",
-        "required": [
-          "id",
-          "suggestion",
-          "udprn",
-          "umprn",
-          "urls"
-        ],
-        "properties": {
-          "id": {
-            "$ref": "#/components/schemas/ID"
-          },
-          "suggestion": {
-            "type": "string",
-            "description": "Address suggestion for your given query.",
-            "example": "Flat 6, 12 Roskear, Camborne, TR14"
-          },
-          "udprn": {
-            "$ref": "#/components/schemas/UDPRN"
-          },
-          "umprn": {
-            "type": "number",
-            "format": "int32",
-            "description": "Optionally returned field, representing the UMPRN of a Multiple Residence household",
-            "example": 51103417
-          },
-          "urls": {
-            "type": "object",
-            "required": [
-              "udprn",
-              "umprn"
-            ],
-            "properties": {
-              "udprn": {
-                "type": "string",
-                "description": "URL to retrieve the entire details for a given address suggestion by the UDPRN",
-                "example": "/v1/udprn/50985827"
-              },
-              "umprn": {
-                "type": "string",
-                "description": "Optionally returned field, to retrieve the entire details for a suggested Multiple Residence household",
-                "example": "/v1/umprn/51103417"
-              }
-            }
-          }
-        }
-      },
-      "NybSuggestion": {
-        "title": "Not Yet Built Address Autocompletion Hit",
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/PafSuggestion"
-          }
-        ]
-      },
-      "PafwSuggestion": {
-        "title": "Welsh Postcode Address File Address Autocompletion Hit",
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/PafSuggestion"
-          }
-        ]
-      },
-      "GlobalAddressSuggestion": {
-        "title": "Global Address Autocompletion Suggestion",
+      "AddressSuggestion": {
+        "title": "Address Suggestion",
         "description": "Represents an address suggestion for any address in the world",
         "type": "object",
         "required": [
@@ -3324,12 +3192,53 @@
             "example": "Flat 6, 12 Roskear, Camborne, TR14"
           },
           "urls": {
+            "type": "object"
+          }
+        }
+      },
+      "UkAddressSuggestion": {
+        "title": "UK Address Suggestion",
+        "description": "Represents a possible address given an autocomplete query.\n\nUK Address Suggestions will return a UDPRN attribute if it references a deliverable endpoint found on Royal Mail's Postcode Address File dataset.\n\nUK Address Suggestion will return a UMPRN if it references a multiple occupancy premise found on Royal Mail's Multiple Residence dataset.\n",
+        "type": "object",
+        "required": [
+          "id",
+          "suggestion",
+          "udprn",
+          "urls"
+        ],
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "suggestion": {
+            "type": "string",
+            "description": "Address suggestion for a given query.",
+            "example": "Flat 6, 12 Roskear, Camborne, TR14"
+          },
+          "udprn": {
+            "$ref": "#/components/schemas/UDPRN"
+          },
+          "umprn": {
+            "type": "number",
+            "format": "int32",
+            "description": "Optionally returned field, representing the UMPRN of a Multiple Residence household",
+            "example": 51103417
+          },
+          "urls": {
+            "required": [
+              "udprn"
+            ],
             "type": "object",
             "properties": {
-              "id": {
+              "udprn": {
                 "type": "string",
                 "description": "URL to retrieve the entire details for a given address suggestion by the UDPRN",
                 "example": "/v1/udprn/50985827"
+              },
+              "umprn": {
+                "type": "string",
+                "description": "Optionally returned field, to retrieve the entire details for a suggested Multiple Residence household",
+                "example": "/v1/umprn/51103417"
               }
             }
           }
@@ -3355,19 +3264,10 @@
                 "items": {
                   "oneOf": [
                     {
-                      "$ref": "#/components/schemas/PafSuggestion"
+                      "$ref": "#/components/schemas/AddressSuggestion"
                     },
                     {
-                      "$ref": "#/components/schemas/MrSuggestion"
-                    },
-                    {
-                      "$ref": "#/components/schemas/NybSuggestion"
-                    },
-                    {
-                      "$ref": "#/components/schemas/PafwSuggestion"
-                    },
-                    {
-                      "$ref": "#/components/schemas/GlobalAddressSuggestion"
+                      "$ref": "#/components/schemas/UkAddressSuggestion"
                     }
                   ]
                 }
@@ -4506,6 +4406,9 @@
                     },
                     {
                       "$ref": "#/components/schemas/NybAddress"
+                    },
+                    {
+                      "$ref": "#/components/schemas/WelshPafAddress"
                     }
                   ]
                 }

--- a/dist/openapi.json
+++ b/dist/openapi.json
@@ -996,7 +996,7 @@
           "UK"
         ],
         "summary": "Extract Addresses",
-        "description": "Extract a list of complete addresses that match the query ordered by relevance score. This query accepts an optional limit and page query (defaults to 10 and 0 respectively).\n\nIf a valid postcode is passed as the query string, the entire address list for that postcode is passed as a result. Note, in these cases, limit and page parameters are ignored.\n\nThis API is designed as a multi-purpose tool for generating address lists, cleansing and wholesale data extraction according to specific parameters.\n\nFor address autocomplete, see our address finder API - which is designed for speed and address completion.\n\n## Filters\n\nYou can strictly narrow your result by adding filters to your query string which correspond with an address attribute.\n\nFor instance, you can restrict to postcode `SW1A 2AA` by appending `postcode=sw1a2aa`.\n\nIf a filter term is invalid, e.g. `postcode=SW1A2AAA`, then an empty result set is returned and no lookup is incurred.\n\nYou can also scope using multiple terms for the same filter with a comma separated list of terms. E.g. Restrict results to E1, E2 and E3 outward codes: `postcode_outward=e1,e2,e3`. Multiple terms are `OR`'ed, i.e. the matching result sets are combined.\n\nAll filters can accept multiple terms unless stated otherwise below.\n\nMultiple filters can also be combined. E.g. Restrict results to small user organisations in the N postcode area: `su_organisation_indicator=Y&postcode_area=n`. Multiple filters are `AND`'ed, i.e. each additional filter narrows the result set.\n\nA combined maximum of 5 terms are allowed across all filters.\n\n## Biases\n\nYou can boost certain addresses results that correspond with a certain address attribute. All bias searches are prefixed with `bias_`.\n\nBiased searches, unlike filtered searches, also allow unmatched addresses to appear . These will rank lower.\n\nFor instance, you can boost addresses with postcode areas `SW` and `SE` by appending `bias_postcode_area=SW,SE`.\n\nIf a bias term is invalid, e.g. `bias_postcode=SW1A2AAA` no bias effect is applied.\n\nYou may scope using multiple terms for the same bias with a comma separated list of terms. E.g. Restrict results to `E1`, `E2` and `E3` outward codes: `bias_postcode_outward=e1,e2,e3`.\n\nAll biases can accept multiple terms unless stated otherwise below.\n\nA combined maximum of 5 terms are allowed across all biases.\n\n## Search by Postcode and Building Name or Number\n\nSearch by postcode and building attribute with the postcode filter and query argument. E.g. For \"SW1A 2AA Prime Minister\" `/v1/addresses?postcode=sw1a2aa&q=prime minister`.\n\nThe advantage of using filters is a postcode mismatch does not result in a lookup as no results are returned.\n\n#### Search By UPRN\n\nSearch by UPRN using the `uprn` filter and excluding the query argument. E.g. `/v1/addresses?uprn=100`.\n\n## Testing\n\n- **ID1 1QD** Returns a successful query response `2000`\n- **ID1 KFA** Returns an empty query response `2000`\n- **ID1 CLIP** Returns \"no lookups remaining\" error `4020`\n- **ID1 CHOP** Returns \"daily (or individual) lookup limit breached\" error `4021`\n\nTest request undergo the usual authentication and restriction rules. This is to help surface any issues that occur during implementation and does not cost you a lookup.\n",
+        "description": "Extract a list of complete addresses that match the query ordered by relevance score. This query accepts an optional limit and page query (defaults to 10 and 0 respectively).\n\nIf a valid postcode is passed as the query string, the entire address list for that postcode is passed as a result. Note, in these cases, limit and page parameters are ignored.\n\nThis API is designed as a multi-purpose tool for generating address lists, cleansing and wholesale data extraction according to specific parameters.\n\nFor address autocomplete, see our address finder API - which is designed for speed and address completion.\n\n## Reverse Geocoding\n\nReturn a list of addresses around a point using the lon= and lat= querystring arguments. Addresses will be sorted in order of distance to the point. The search radius is 100m.\n\n## Filters\n\nYou can strictly narrow your result by adding filters to your query string which correspond with an address attribute.\n\nFor instance, you can restrict to postcode `SW1A 2AA` by appending `postcode=sw1a2aa`.\n\nIf a filter term is invalid, e.g. `postcode=SW1A2AAA`, then an empty result set is returned and no lookup is incurred.\n\nYou can also scope using multiple terms for the same filter with a comma separated list of terms. E.g. Restrict results to E1, E2 and E3 outward codes: `postcode_outward=e1,e2,e3`. Multiple terms are `OR`'ed, i.e. the matching result sets are combined.\n\nAll filters can accept multiple terms unless stated otherwise below.\n\nMultiple filters can also be combined. E.g. Restrict results to small user organisations in the N postcode area: `su_organisation_indicator=Y&postcode_area=n`. Multiple filters are `AND`'ed, i.e. each additional filter narrows the result set.\n\nA combined maximum of 5 terms are allowed across all filters.\n\n## Biases\n\nYou can boost certain addresses results that correspond with a certain address attribute. All bias searches are prefixed with `bias_`.\n\nBiased searches, unlike filtered searches, also allow unmatched addresses to appear . These will rank lower.\n\nFor instance, you can boost addresses with postcode areas `SW` and `SE` by appending `bias_postcode_area=SW,SE`.\n\nIf a bias term is invalid, e.g. `bias_postcode=SW1A2AAA` no bias effect is applied.\n\nYou may scope using multiple terms for the same bias with a comma separated list of terms. E.g. Restrict results to `E1`, `E2` and `E3` outward codes: `bias_postcode_outward=e1,e2,e3`.\n\nAll biases can accept multiple terms unless stated otherwise below.\n\nA combined maximum of 5 terms are allowed across all biases.\n\n## Search by Postcode and Building Name or Number\n\nSearch by postcode and building attribute with the postcode filter and query argument. E.g. For \"SW1A 2AA Prime Minister\" `/v1/addresses?postcode=sw1a2aa&q=prime minister`.\n\nThe advantage of using filters is a postcode mismatch does not result in a lookup as no results are returned.\n\n#### Search By UPRN\n\nSearch by UPRN using the `uprn` filter and excluding the query argument. E.g. `/v1/addresses?uprn=100`.\n\n## Testing\n\n- **ID1 1QD** Returns a successful query response `2000`\n- **ID1 KFA** Returns an empty query response `2000`\n- **ID1 CLIP** Returns \"no lookups remaining\" error `4020`\n- **ID1 CHOP** Returns \"daily (or individual) lookup limit breached\" error `4021`\n\nTest request undergo the usual authentication and restriction rules. This is to help surface any issues that occur during implementation and does not cost you a lookup.\n",
         "operationId": "Addresses",
         "parameters": [
           {
@@ -1044,6 +1044,24 @@
             "explode": false,
             "schema": {
               "$ref": "#/components/schemas/FilterParam"
+            }
+          },
+          {
+            "name": "lon",
+            "in": "query",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "$ref": "#/components/schemas/AddressLongitudeParam"
+            }
+          },
+          {
+            "name": "lat",
+            "in": "query",
+            "style": "form",
+            "explode": false,
+            "schema": {
+              "$ref": "#/components/schemas/AddressLatitudeParam"
             }
           },
           {
@@ -4404,6 +4422,24 @@
             ]
           }
         }
+      },
+      "AddressLongitudeParam": {
+        "title": "Longitude",
+        "type": "number",
+        "format": "float",
+        "description": "Longitude query for reverse geocoding.\n\nAn accompanying latitude (lat=) query must be submitted for a valid reverse geocode query.\n",
+        "minimum": -90,
+        "maximum": 90,
+        "example": -0.12767
+      },
+      "AddressLatitudeParam": {
+        "title": "Latitude",
+        "type": "number",
+        "format": "float",
+        "description": "Latitude query for reverse geocoding.\n\nAn accompanying longitude (lon=) query must be submitted for a valid reverse geocode query.\n",
+        "minimum": -90,
+        "maximum": 90,
+        "example": 51.503541
       },
       "AddressResponse": {
         "title": "Address Search Response",

--- a/dist/openapi.yaml
+++ b/dist/openapi.yaml
@@ -1438,6 +1438,14 @@ paths:
         for speed and address completion.
 
 
+        ## Reverse Geocoding
+
+
+        Return a list of addresses around a point using the lon= and lat=
+        querystring arguments. Addresses will be sorted in order of distance to
+        the point. The search radius is 100m.
+
+
         ## Filters
 
 
@@ -1572,6 +1580,18 @@ paths:
           explode: false
           schema:
             $ref: '#/components/schemas/FilterParam'
+        - name: lon
+          in: query
+          style: form
+          explode: false
+          schema:
+            $ref: '#/components/schemas/AddressLongitudeParam'
+        - name: lat
+          in: query
+          style: form
+          explode: false
+          schema:
+            $ref: '#/components/schemas/AddressLatitudeParam'
         - name: postcode_outward
           in: query
           style: form
@@ -4463,6 +4483,32 @@ components:
           oneOf:
             - $ref: '#/components/schemas/UspsAddress'
             - $ref: '#/components/schemas/UsaGlobalAddress'
+    AddressLongitudeParam:
+      title: Longitude
+      type: number
+      format: float
+      description: >
+        Longitude query for reverse geocoding.
+
+
+        An accompanying latitude (lat=) query must be submitted for a valid
+        reverse geocode query.
+      minimum: -90
+      maximum: 90
+      example: -0.12767
+    AddressLatitudeParam:
+      title: Latitude
+      type: number
+      format: float
+      description: >
+        Latitude query for reverse geocoding.
+
+
+        An accompanying longitude (lon=) query must be submitted for a valid
+        reverse geocode query.
+      minimum: -90
+      maximum: 90
+      example: 51.503541
     AddressResponse:
       title: Address Search Response
       type: object

--- a/dist/openapi.yaml
+++ b/dist/openapi.yaml
@@ -1,6 +1,6 @@
 openapi: 3.0.3
 info:
-  version: 2.1.1
+  version: 3.0.0
   license:
     name: AGPLv3
     url: https://opensource.org/licenses/AGPL-3.0
@@ -71,7 +71,7 @@ info:
 
     ```
 
-    Authorization: IDEALPOSTCODES api_key="iddqd" [other_key="foo"]
+    Authorization: api_key="iddqd" [other_key="foo"]
 
     ```
 
@@ -379,19 +379,35 @@ tags:
 
       Useful if you need to configure your integration remotely rather than
       editing code in situ.
+  - name: suggestion
+    x-displayName: Address Suggestion
+    description: >
+      Address Suggestions are simple, human readable representations of an
+      address. This format is sufficient tfor a user to determine an address
+      match in an address autocomplete interface. A second request must be made
+      to the API to gather fully validated address.
+
+
+      See our Address Search APIs for more information on address
+      autocompletion.
+
+
+      <SchemaDefinition schemaRef="#/components/schemas/AddressSuggestion" />
   - name: usps_address
     x-displayName: US Address
     description: |
+      Standard US Address format as reported by USPS.
+
       <SchemaDefinition schemaRef="#/components/schemas/UspsAddress" />
   - name: uk_address
     x-displayName: UK Address
-    description: |
-      <SchemaDefinition schemaRef="#/components/schemas/PafAddress" />
-  - name: suggestion
-    x-displayName: Global Address Suggestion
     description: >
-      <SchemaDefinition schemaRef="#/components/schemas/GlobalAddressSuggestion"
-      />
+      Standard UK Address format as reported by Royal Mail's Postcode Address
+      File (PAF). PAF is the most complete and up-to-date address database in
+      the UK.
+
+
+      <SchemaDefinition schemaRef="#/components/schemas/PafAddress" />
 x-tagGroups:
   - name: Address Search
     tags:
@@ -476,7 +492,6 @@ paths:
         - name: api_key
           in: query
           style: form
-          required: true
           explode: false
           schema:
             $ref: '#/components/schemas/ApiKeyParam'
@@ -573,7 +588,6 @@ paths:
             type: string
         - name: api_key
           in: query
-          required: true
           style: form
           explode: false
           schema:
@@ -660,7 +674,6 @@ paths:
           schema:
             type: string
         - name: api_key
-          required: true
           in: query
           style: form
           explode: false
@@ -763,7 +776,6 @@ paths:
         - name: user_token
           in: query
           style: form
-          required: true
           explode: false
           schema:
             $ref: '#/components/schemas/UserTokenParam'
@@ -975,28 +987,27 @@ paths:
       summary: Find Address
       description: >
         The address autocomplete API returns a list of address suggestions that
-        match the query ordered by relevance score.
+        match the query ordered by relevance.
 
 
         This API can be used to power realtime address finders, also known as
         address autofill or address autocomplete.
 
 
-        If you wish to quickly add address autocompletion to your address forms,
-        see [Address Finder](/address-finder) and [associated
-        demos](/address-finder-demo).
+        Consider using our Address Autocomplete JavaScript libraries to add
+        address lookup to a form in moments.
 
 
         ## Implementing Address Autocomplete
 
 
-        Retrieving addresses using Address Autocomplete is a 2 step process.
+        Rapid address autocompletion using our Address Autocomplete API is a 2
+        step process.
 
 
         1. Retrieve partial address suggestions via `/autocomplete/addresses`
 
-        2. Retrieve the entire address by following the URL provided by the
-        suggestion
+        2. Retrieve the entire address with the ID provided in the suggestion
 
 
         Step 2 will decrement your lookup balance.
@@ -1009,11 +1020,8 @@ paths:
 
 
         You can strictly narrow your result by adding filters to your
-        querystring which correspond with an address attribute.
-
-
-        For instance, you can restrict to postcode `SW1A 2AA` by appending
-        `postcode=sw1a2aa`.
+        querystring. For instance, you can restrict to postcode `SW1A 2AA` by
+        appending `postcode=sw1a2aa`.
 
 
         If a filter term is invalid, e.g. `postcode=SW1A2AAA`, then an empty
@@ -1022,17 +1030,17 @@ paths:
 
         You can also scope using multiple terms for the same filter with a comma
         separated list of terms. E.g. Restrict results to E1, E2 and E3 outward
-        codes: `postcode_outward=e1,e2,e3`. Multiple terms are
-        <code>OR</code>'ed, i.e. the matching result sets are combined.
+        codes: `postcode_outward=e1,e2,e3`. Multiple terms are `OR`'ed, i.e. the
+        matching result sets are combined.
 
 
         All filters can accept multiple terms unless stated otherwise below.
 
 
-        Multiple filters can also be combined. E.g. Restrict results to small
-        user organisations in the N postcode area:
+        Filters can also be combined. E.g. Restrict results to small user
+        organisations in the N postcode area:
         `su_organisation_indicator=Y&postcode_area=n`. Multiple filters are
-        <code>AND</code>'ed, i.e. each additional filter narrows the result set.
+        `AND`'ed, i.e. each additional filter narrows the result set.
 
 
         A maximum of **10** terms are allowed across all filters.
@@ -1041,21 +1049,20 @@ paths:
         ## Biases
 
 
-        You can boost certain addresses results that correspond with a certain
-        address attribute. All bias searches are prefixed with `bias_`.
+        You can boost certain addresses results that match specific address
+        criteria. All bias searches are prefixed with `bias_`.
 
 
-        Biased searches, unlike filtered searches, also allow unmatched
-        addresses to appear. These will rank lower.
+        Biasing (unlike filtering) also allow unmatched addresses to appear with
+        lower precedence.
 
 
         For instance, can boost addresses with postcode areas `SW` and `SE` by
         appending `bias_postcode_area=SW,SE`.
 
 
-        No bias effect applies to bias terms that are invalid.
-
-        e.g. `bias_postcode=SW1A2AAA`
+        No bias effect applies to bias terms that are invalid. e.g.
+        `bias_postcode=SW1A2AAA`
 
 
         You may scope using multiple terms for the same bias with a comma
@@ -1119,7 +1126,6 @@ paths:
         - name: api_key
           in: query
           style: form
-          required: true
           explode: false
           schema:
             $ref: '#/components/schemas/ApiKeyParam'
@@ -1323,7 +1329,6 @@ paths:
             type: string
         - name: api_key
           in: query
-          required: true
           style: form
           explode: false
           schema:
@@ -1378,7 +1383,6 @@ paths:
             type: string
         - name: api_key
           in: query
-          required: true
           style: form
           explode: false
           schema:
@@ -1721,7 +1725,6 @@ paths:
             format: int32
         - name: user_token
           in: query
-          required: true
           style: form
           explode: false
           schema:
@@ -1765,7 +1768,6 @@ paths:
             $ref: '#/components/schemas/ApiKeyParam'
         - name: user_token
           in: query
-          required: true
           style: form
           explode: false
           schema:
@@ -1807,7 +1809,6 @@ paths:
             $ref: '#/components/schemas/LicenseeParam'
         - name: user_token
           in: query
-          required: true
           style: form
           explode: false
           schema:
@@ -1845,7 +1846,6 @@ paths:
             $ref: '#/components/schemas/LicenseeParam'
         - name: user_token
           in: query
-          required: true
           style: form
           explode: false
           schema:
@@ -1905,7 +1905,6 @@ paths:
             $ref: '#/components/schemas/LicenseeParam'
         - name: user_token
           in: query
-          required: true
           style: form
           explode: false
           schema:
@@ -1940,7 +1939,6 @@ paths:
             $ref: '#/components/schemas/ApiKeyParam'
         - name: user_token
           in: query
-          required: true
           style: form
           explode: false
           schema:
@@ -1980,7 +1978,6 @@ paths:
             $ref: '#/components/schemas/ApiKeyParam'
         - name: user_token
           in: query
-          required: true
           style: form
           explode: false
           schema:
@@ -2075,7 +2072,6 @@ paths:
             $ref: '#/components/schemas/ConfigParam'
         - name: user_token
           in: query
-          required: true
           style: form
           explode: false
           schema:
@@ -2153,7 +2149,6 @@ paths:
             $ref: '#/components/schemas/ConfigParam'
         - name: user_token
           in: query
-          required: true
           style: form
           explode: false
           schema:
@@ -2376,8 +2371,6 @@ components:
       oneOf:
         - type: string
           description: If premise is not multiple occupancy, this will be an empty string
-          enum:
-            - ''
         - type: number
           description: If premise is multiple occupancy, this will be an integer
           example: 983729
@@ -2524,8 +2517,6 @@ components:
       oneOf:
         - type: string
           description: Empty string `""` if not available
-          enum:
-            - ''
         - type: number
           description: Represents longitude
           example: 0.002823
@@ -2541,8 +2532,6 @@ components:
       oneOf:
         - type: string
           description: Empty string `""` if not available
-          enum:
-            - ''
         - type: number
           description: Represents latitude
           example: 52.938278
@@ -2560,8 +2549,6 @@ components:
       oneOf:
         - type: string
           description: Empty string `""` if not available
-          enum:
-            - ''
         - type: number
           description: Metres offset east from origin
           example: 9382
@@ -2579,8 +2566,6 @@ components:
       oneOf:
         - type: string
           description: Empty string `""` if not available
-          enum:
-            - ''
         - type: number
           description: Metres offset north from origin
           example: 123932
@@ -2615,6 +2600,7 @@ components:
       enum:
         - paf
         - pafw
+        - pafa
         - mr
         - nyb
         - usps
@@ -3384,88 +3370,8 @@ components:
         Biases search based on approximate geolocation of IP address.
         Set `bias_ip=true` to enable.
       example: bias_ip=true
-    PafSuggestion:
-      title: UK Postcode Address File Address Autocompletion Hit
-      description: Represents an address suggestion from the UK Postcode Address File.
-      type: object
-      required:
-        - id
-        - suggestion
-        - udprn
-        - urls
-      properties:
-        id:
-          $ref: '#/components/schemas/ID'
-        suggestion:
-          type: string
-          description: Address suggestion for your given query.
-          example: Flat 6, 12 Roskear, Camborne, TR14
-        udprn:
-          $ref: '#/components/schemas/UDPRN'
-        urls:
-          required:
-            - udprn
-          type: object
-          properties:
-            udprn:
-              type: string
-              description: >-
-                URL to retrieve the entire details for a given address
-                suggestion by the UDPRN
-              example: /v1/udprn/50985827
-    MrSuggestion:
-      title: Multiple Residence Address Autocompletion Hit
-      type: object
-      required:
-        - id
-        - suggestion
-        - udprn
-        - umprn
-        - urls
-      properties:
-        id:
-          $ref: '#/components/schemas/ID'
-        suggestion:
-          type: string
-          description: Address suggestion for your given query.
-          example: Flat 6, 12 Roskear, Camborne, TR14
-        udprn:
-          $ref: '#/components/schemas/UDPRN'
-        umprn:
-          type: number
-          format: int32
-          description: >-
-            Optionally returned field, representing the UMPRN of a Multiple
-            Residence household
-          example: 51103417
-        urls:
-          type: object
-          required:
-            - udprn
-            - umprn
-          properties:
-            udprn:
-              type: string
-              description: >-
-                URL to retrieve the entire details for a given address
-                suggestion by the UDPRN
-              example: /v1/udprn/50985827
-            umprn:
-              type: string
-              description: >-
-                Optionally returned field, to retrieve the entire details for a
-                suggested Multiple Residence household
-              example: /v1/umprn/51103417
-    NybSuggestion:
-      title: Not Yet Built Address Autocompletion Hit
-      allOf:
-        - $ref: '#/components/schemas/PafSuggestion'
-    PafwSuggestion:
-      title: Welsh Postcode Address File Address Autocompletion Hit
-      allOf:
-        - $ref: '#/components/schemas/PafSuggestion'
-    GlobalAddressSuggestion:
-      title: Global Address Autocompletion Suggestion
+    AddressSuggestion:
+      title: Address Suggestion
       description: Represents an address suggestion for any address in the world
       type: object
       required:
@@ -3481,13 +3387,58 @@ components:
           example: Flat 6, 12 Roskear, Camborne, TR14
         urls:
           type: object
+    UkAddressSuggestion:
+      title: UK Address Suggestion
+      description: >
+        Represents a possible address given an autocomplete query.
+
+
+        UK Address Suggestions will return a UDPRN attribute if it references a
+        deliverable endpoint found on Royal Mail's Postcode Address File
+        dataset.
+
+
+        UK Address Suggestion will return a UMPRN if it references a multiple
+        occupancy premise found on Royal Mail's Multiple Residence dataset.
+      type: object
+      required:
+        - id
+        - suggestion
+        - udprn
+        - urls
+      properties:
+        id:
+          $ref: '#/components/schemas/ID'
+        suggestion:
+          type: string
+          description: Address suggestion for a given query.
+          example: Flat 6, 12 Roskear, Camborne, TR14
+        udprn:
+          $ref: '#/components/schemas/UDPRN'
+        umprn:
+          type: number
+          format: int32
+          description: >-
+            Optionally returned field, representing the UMPRN of a Multiple
+            Residence household
+          example: 51103417
+        urls:
+          required:
+            - udprn
+          type: object
           properties:
-            id:
+            udprn:
               type: string
               description: >-
                 URL to retrieve the entire details for a given address
                 suggestion by the UDPRN
               example: /v1/udprn/50985827
+            umprn:
+              type: string
+              description: >-
+                Optionally returned field, to retrieve the entire details for a
+                suggested Multiple Residence household
+              example: /v1/umprn/51103417
     AutocompleteResponse:
       title: Address Autocomplete Response
       type: object
@@ -3505,11 +3456,8 @@ components:
               type: array
               items:
                 oneOf:
-                  - $ref: '#/components/schemas/PafSuggestion'
-                  - $ref: '#/components/schemas/MrSuggestion'
-                  - $ref: '#/components/schemas/NybSuggestion'
-                  - $ref: '#/components/schemas/PafwSuggestion'
-                  - $ref: '#/components/schemas/GlobalAddressSuggestion'
+                  - $ref: '#/components/schemas/AddressSuggestion'
+                  - $ref: '#/components/schemas/UkAddressSuggestion'
         code:
           type: integer
           format: int32
@@ -4514,6 +4462,7 @@ components:
                   - $ref: '#/components/schemas/PafAddress'
                   - $ref: '#/components/schemas/MrAddress'
                   - $ref: '#/components/schemas/NybAddress'
+                  - $ref: '#/components/schemas/WelshPafAddress'
             total:
               minimum: 0
               maximum: 10000

--- a/dist/openapi.yaml
+++ b/dist/openapi.yaml
@@ -2885,12 +2885,33 @@ components:
           type: string
           enum:
             - Success
+    Context:
+      title: Context
+      type: string
+      enum:
+        - GBR
+        - USA
+      description: Limits search results within a geographical boundary or country.
+    NoContext:
+      title: No Context Provided
+      type: string
+      enum:
+        - ''
+      description: Empty string if no context is provided or key check has failed
     ApiKey:
       title: Key
       type: object
       required:
         - available
+        - context
       properties:
+        context:
+          description: >
+            Returns current context if it is in the list of available contexts
+            for this key.
+          oneOf:
+            - $ref: '#/components/schemas/Context'
+            - $ref: '#/components/schemas/NoContext'
         available:
           description: |
             Determines whether the key can be used by the requesting agent. 
@@ -3044,7 +3065,7 @@ components:
         expires:
           x-nullable: true
           type: string
-          example: 2022-01-06T11:41:27.092Z
+          example: '2022-01-06T11:41:27.092Z'
           description: >-
             `string` or `null` The date when this purchase will expire in
             simplified 
@@ -3176,11 +3197,11 @@ components:
         start:
           type: string
           description: Start date in ISO 8601 format.
-          example: 2015-01-22T15:08:06.609Z
+          example: '2015-01-22T15:08:06.609Z'
         end:
           type: string
           description: End date in ISO 8601 format.
-          example: 2015-01-23T15:08:06.609Z
+          example: '2015-01-23T15:08:06.609Z'
         total:
           type: integer
           description: Total of paid lookups performed in specified period.
@@ -3201,7 +3222,7 @@ components:
             properties:
               date:
                 type: string
-                example: 2015-01-22T00:00:00.000Z
+                example: '2015-01-22T00:00:00.000Z'
               count:
                 type: integer
                 format: int32
@@ -3225,13 +3246,6 @@ components:
           type: string
           enum:
             - Success
-    Context:
-      title: Context
-      type: string
-      enum:
-        - gbr
-        - usa
-      description: Limits search results within a geographical boundary or country.
     LimitParam:
       title: Limit
       description: >
@@ -3478,6 +3492,26 @@ components:
               $ref: '#/components/schemas/Dataset'
               enum:
                 - pafw
+    PafAliasAddress:
+      title: PAF Alias Address
+      description: >
+        PAF Aliases addresses are alternate ways to present an address already
+        found on PAF.
+
+
+        Alias data is information the public chooses to use when addressing
+        mail, but which isn’t actually required for delivery purposes.  The
+        Alias data contains records of alternative address details that are
+        included in the address but not necessarily needed for delivery
+        purposes.
+      allOf:
+        - $ref: '#/components/schemas/PafAddress'
+        - type: object
+          properties:
+            dataset:
+              $ref: '#/components/schemas/Dataset'
+              enum:
+                - pafa
     GbrGlobalAddress:
       title: Global Address
       description: Global (non-UK) address in the UK address format
@@ -3664,6 +3698,7 @@ components:
             - $ref: '#/components/schemas/PafAddress'
             - $ref: '#/components/schemas/MrAddress'
             - $ref: '#/components/schemas/WelshPafAddress'
+            - $ref: '#/components/schemas/PafAliasAddress'
             - $ref: '#/components/schemas/NybAddress'
             - $ref: '#/components/schemas/GbrGlobalAddress'
     usps_dataset:
@@ -4463,6 +4498,7 @@ components:
                   - $ref: '#/components/schemas/MrAddress'
                   - $ref: '#/components/schemas/NybAddress'
                   - $ref: '#/components/schemas/WelshPafAddress'
+                  - $ref: '#/components/schemas/PafAliasAddress'
             total:
               minimum: 0
               maximum: 10000
@@ -4553,7 +4589,7 @@ components:
                 Typically begins `sk_`.
             createdAt:
               type: string
-              example: 2016-01-21T17:14:49.971Z
+              example: '2016-01-21T17:14:49.971Z'
               description: Timestamp for when the licensee was created
             daily:
               required:
@@ -4571,7 +4607,7 @@ components:
                     represented b `licesees.daily.updatedAt`
                 updatedAt:
                   type: string
-                  example: 2016-08-05T16:43:28.865Z
+                  example: '2016-08-05T16:43:28.865Z'
                   description: The timestamp when the limit was last used.
     LicenseesResponse:
       title: Licensee List Response
@@ -4633,11 +4669,11 @@ components:
       properties:
         updatedAt:
           type: string
-          example: 2016-01-21T17:14:49.971Z
+          example: '2016-01-21T17:14:49.971Z'
           description: Timestamp for when the config was created
         createdAt:
           type: string
-          example: 2016-01-21T17:14:49.971Z
+          example: '2016-01-21T17:14:49.971Z'
           description: Timestamp for when the config was updated
         name:
           type: string

--- a/openapi.ts
+++ b/openapi.ts
@@ -138,18 +138,18 @@ export interface paths {
   };
   "/autocomplete/addresses": {
     /**
-     * The address autocomplete API returns a list of address suggestions that match the query ordered by relevance score.
+     * The address autocomplete API returns a list of address suggestions that match the query ordered by relevance.
      *
      * This API can be used to power realtime address finders, also known as address autofill or address autocomplete.
      *
-     * If you wish to quickly add address autocompletion to your address forms, see [Address Finder](/address-finder) and [associated demos](/address-finder-demo).
+     * Consider using our Address Autocomplete JavaScript libraries to add address lookup to a form in moments.
      *
      * ## Implementing Address Autocomplete
      *
-     * Retrieving addresses using Address Autocomplete is a 2 step process.
+     * Rapid address autocompletion using our Address Autocomplete API is a 2 step process.
      *
      * 1. Retrieve partial address suggestions via `/autocomplete/addresses`
-     * 2. Retrieve the entire address by following the URL provided by the suggestion
+     * 2. Retrieve the entire address with the ID provided in the suggestion
      *
      * Step 2 will decrement your lookup balance.
      *
@@ -157,30 +157,27 @@ export interface paths {
      *
      * ## Filters
      *
-     * You can strictly narrow your result by adding filters to your querystring which correspond with an address attribute.
-     *
-     * For instance, you can restrict to postcode `SW1A 2AA` by appending `postcode=sw1a2aa`.
+     * You can strictly narrow your result by adding filters to your querystring. For instance, you can restrict to postcode `SW1A 2AA` by appending `postcode=sw1a2aa`.
      *
      * If a filter term is invalid, e.g. `postcode=SW1A2AAA`, then an empty result set is returned and no lookup is incurred.
      *
-     * You can also scope using multiple terms for the same filter with a comma separated list of terms. E.g. Restrict results to E1, E2 and E3 outward codes: `postcode_outward=e1,e2,e3`. Multiple terms are <code>OR</code>'ed, i.e. the matching result sets are combined.
+     * You can also scope using multiple terms for the same filter with a comma separated list of terms. E.g. Restrict results to E1, E2 and E3 outward codes: `postcode_outward=e1,e2,e3`. Multiple terms are `OR`'ed, i.e. the matching result sets are combined.
      *
      * All filters can accept multiple terms unless stated otherwise below.
      *
-     * Multiple filters can also be combined. E.g. Restrict results to small user organisations in the N postcode area: `su_organisation_indicator=Y&postcode_area=n`. Multiple filters are <code>AND</code>'ed, i.e. each additional filter narrows the result set.
+     * Filters can also be combined. E.g. Restrict results to small user organisations in the N postcode area: `su_organisation_indicator=Y&postcode_area=n`. Multiple filters are `AND`'ed, i.e. each additional filter narrows the result set.
      *
      * A maximum of **10** terms are allowed across all filters.
      *
      * ## Biases
      *
-     * You can boost certain addresses results that correspond with a certain address attribute. All bias searches are prefixed with `bias_`.
+     * You can boost certain addresses results that match specific address criteria. All bias searches are prefixed with `bias_`.
      *
-     * Biased searches, unlike filtered searches, also allow unmatched addresses to appear. These will rank lower.
+     * Biasing (unlike filtering) also allow unmatched addresses to appear with lower precedence.
      *
      * For instance, can boost addresses with postcode areas `SW` and `SE` by appending `bias_postcode_area=SW,SE`.
      *
-     * No bias effect applies to bias terms that are invalid.
-     * e.g. `bias_postcode=SW1A2AAA`
+     * No bias effect applies to bias terms that are invalid. e.g. `bias_postcode=SW1A2AAA`
      *
      * You may scope using multiple terms for the same bias with a comma separated list of terms. E.g. Restrict results to `E1`, `E2` and `E3` outward codes: <code>bias_postcode_outward=e1,e2,e3</code>.
      *
@@ -436,7 +433,7 @@ export interface components {
      * UMPRN
      * @description A small minority of individual premises (as identified by a UDPRN) may have multiple occupants behind the same letterbox. These are known as Multiple Residence occupants and can be queried via the Multiple Residence dataset. Simple, unique reference number for each Multiple Residence occupant. 8-character numeric code. Note: this will be an empty string `""` when not used for legacy reasons
      */
-    UMPRN: "" | number;
+    UMPRN: string | number;
     /**
      * Postcode Type
      * @description This indicates the type of user. It can only take the values 'S' or 'L' indicating small or large respectively. Large User Postcodes. These are assigned to one single address either due to the large volume of mail received at that address, or because a PO Box or Selectapost service has been set up. Small User Postcodes. These identify a group of Delivery Points. On average there are 15 Delivery Points per Postcode. However this can vary between 1 and, in some cases, 100. There will never be more than 100 Delivery Points on a Postcode.
@@ -523,22 +520,22 @@ export interface components {
      * Longitude
      * @description The longitude of the postcode (WGS84/ETRS89). Accurate at the postcode level Can be a positive or negative decimal. E.g. -0.1283983 Returns an empty string if no location data is available.  Otherwise, a number is returned
      */
-    Longitude: "" | number;
+    Longitude: string | number;
     /**
      * Longitude
      * @description The latitude of the postcode (WGS84/ETRS89). Accurate at the postcode level Can be a positive or negative decimal. E.g. 51.5083983 Returns an empty string if no location data is available.  Otherwise a number is returned.
      */
-    Latitude: "" | number;
+    Latitude: string | number;
     /**
      * Eastings
      * @description Eastings reference using the [Ordnance Survey National Grid reference system](https://en.wikipedia.org/wiki/Ordnance_Survey_National_Grid) Northern Ireland Eastings uses the [Irish Grid Reference System](https://en.wikipedia.org/wiki/Irish_grid_reference_system) Metres from origin. E.g. 550458 Returns an empty string if no location data is available. Otherwise a number is returned
      */
-    Eastings: "" | number;
+    Eastings: string | number;
     /**
      * Eastings
      * @description Northings reference using the [Ordnance Survey National Grid reference system](https://en.wikipedia.org/wiki/Ordnance_Survey_National_Grid) Northern Ireland Northings uses the [Irish Grid Reference System](https://en.wikipedia.org/wiki/Irish_grid_reference_system) Metres from origin. E.g. 180458 Returns an empty string if no location data is available. Otherwise a number is returned
      */
-    Northings: "" | number;
+    Northings: string | number;
     /**
      * Unique Delivery Point Reference Number (UDPRN)
      * @description UPRN stands for Unique Property Reference Number and is maintained by the Ordnance Survey (OS). Local governments in the UK have allocated a unique number for each land or property. See our UPRN guide for more information. Up to 12 digits in length. Multiple Residence premises currently share the same UPRN as the parent premise. May not be available for a small number of Great Britain addresses due to longer update cycles for Ordnance Survey's AddressBase datasets. Returns empty string "" in these instances. Although UPRN takes an integer format, we encode and transmit this data as strings. As a 12 digit number, the UPRN can exceed the maximum safe integer (Number.MAX_SAFE_INTEGER) in most browsers causing this datapoint to be corrupted. Take special care when storing UPRN. As a 12 digit identifier, you will need 64 bits to encode every possible UPRN value.
@@ -555,7 +552,7 @@ export interface components {
      * @description Indicates the provenance of an address
      * @enum {string}
      */
-    Dataset: "paf" | "pafw" | "mr" | "nyb" | "usps";
+    Dataset: "paf" | "pafw" | "pafa" | "mr" | "nyb" | "usps";
     /**
      * ISO Country Code
      * @description 3 letter ISO country code
@@ -1051,30 +1048,30 @@ export interface components {
      */
     BiasIpParam: "true";
     /**
-     * UK Postcode Address File Address Autocompletion Hit
-     * @description Represents an address suggestion from the UK Postcode Address File.
+     * Address Suggestion
+     * @description Represents an address suggestion for any address in the world
      */
-    PafSuggestion: {
+    AddressSuggestion: {
       id: components["schemas"]["ID"];
       /**
-       * @description Address suggestion for your given query.
+       * @description Address Suggestion to be displayed to the user
        * @example Flat 6, 12 Roskear, Camborne, TR14
        */
       suggestion: string;
-      udprn: components["schemas"]["UDPRN"];
-      urls: {
-        /**
-         * @description URL to retrieve the entire details for a given address suggestion by the UDPRN
-         * @example /v1/udprn/50985827
-         */
-        udprn: string;
-      };
+      urls: { [key: string]: unknown };
     };
-    /** Multiple Residence Address Autocompletion Hit */
-    MrSuggestion: {
+    /**
+     * UK Address Suggestion
+     * @description Represents a possible address given an autocomplete query.
+     *
+     * UK Address Suggestions will return a UDPRN attribute if it references a deliverable endpoint found on Royal Mail's Postcode Address File dataset.
+     *
+     * UK Address Suggestion will return a UMPRN if it references a multiple occupancy premise found on Royal Mail's Multiple Residence dataset.
+     */
+    UkAddressSuggestion: {
       id: components["schemas"]["ID"];
       /**
-       * @description Address suggestion for your given query.
+       * @description Address suggestion for a given query.
        * @example Flat 6, 12 Roskear, Camborne, TR14
        */
       suggestion: string;
@@ -1084,7 +1081,7 @@ export interface components {
        * @description Optionally returned field, representing the UMPRN of a Multiple Residence household
        * @example 51103417
        */
-      umprn: number;
+      umprn?: number;
       urls: {
         /**
          * @description URL to retrieve the entire details for a given address suggestion by the UDPRN
@@ -1095,41 +1092,15 @@ export interface components {
          * @description Optionally returned field, to retrieve the entire details for a suggested Multiple Residence household
          * @example /v1/umprn/51103417
          */
-        umprn: string;
-      };
-    };
-    /** Not Yet Built Address Autocompletion Hit */
-    NybSuggestion: components["schemas"]["PafSuggestion"];
-    /** Welsh Postcode Address File Address Autocompletion Hit */
-    PafwSuggestion: components["schemas"]["PafSuggestion"];
-    /**
-     * Global Address Autocompletion Suggestion
-     * @description Represents an address suggestion for any address in the world
-     */
-    GlobalAddressSuggestion: {
-      id: components["schemas"]["ID"];
-      /**
-       * @description Address Suggestion to be displayed to the user
-       * @example Flat 6, 12 Roskear, Camborne, TR14
-       */
-      suggestion: string;
-      urls: {
-        /**
-         * @description URL to retrieve the entire details for a given address suggestion by the UDPRN
-         * @example /v1/udprn/50985827
-         */
-        id?: string;
+        umprn?: string;
       };
     };
     /** Address Autocomplete Response */
     AutocompleteResponse: {
       result: {
         hits: (
-          | components["schemas"]["PafSuggestion"]
-          | components["schemas"]["MrSuggestion"]
-          | components["schemas"]["NybSuggestion"]
-          | components["schemas"]["PafwSuggestion"]
-          | components["schemas"]["GlobalAddressSuggestion"]
+          | components["schemas"]["AddressSuggestion"]
+          | components["schemas"]["UkAddressSuggestion"]
         )[];
       };
       /**
@@ -1760,6 +1731,7 @@ export interface components {
           | components["schemas"]["PafAddress"]
           | components["schemas"]["MrAddress"]
           | components["schemas"]["NybAddress"]
+          | components["schemas"]["WelshPafAddress"]
         )[];
         /** Format: int32 */
         total: number;
@@ -2043,7 +2015,7 @@ export interface operations {
         postcode: components["schemas"]["Postcode"];
       };
       query: {
-        api_key: components["schemas"]["ApiKeyParam"];
+        api_key?: components["schemas"]["ApiKeyParam"];
         filter?: components["schemas"]["FilterParam"];
         page?: components["schemas"]["PageParam"];
       };
@@ -2092,7 +2064,7 @@ export interface operations {
         udprn: string;
       };
       query: {
-        api_key: components["schemas"]["ApiKeyParam"];
+        api_key?: components["schemas"]["ApiKeyParam"];
         filter?: components["schemas"]["FilterParam"];
       };
     };
@@ -2138,7 +2110,7 @@ export interface operations {
         umprn: string;
       };
       query: {
-        api_key: components["schemas"]["ApiKeyParam"];
+        api_key?: components["schemas"]["ApiKeyParam"];
         filter?: components["schemas"]["FilterParam"];
       };
     };
@@ -2196,7 +2168,7 @@ export interface operations {
         key: components["schemas"]["ApiKeyParam"];
       };
       query: {
-        user_token: components["schemas"]["UserTokenParam"];
+        user_token?: components["schemas"]["UserTokenParam"];
       };
     };
     responses: {
@@ -2290,18 +2262,18 @@ export interface operations {
     };
   };
   /**
-   * The address autocomplete API returns a list of address suggestions that match the query ordered by relevance score.
+   * The address autocomplete API returns a list of address suggestions that match the query ordered by relevance.
    *
    * This API can be used to power realtime address finders, also known as address autofill or address autocomplete.
    *
-   * If you wish to quickly add address autocompletion to your address forms, see [Address Finder](/address-finder) and [associated demos](/address-finder-demo).
+   * Consider using our Address Autocomplete JavaScript libraries to add address lookup to a form in moments.
    *
    * ## Implementing Address Autocomplete
    *
-   * Retrieving addresses using Address Autocomplete is a 2 step process.
+   * Rapid address autocompletion using our Address Autocomplete API is a 2 step process.
    *
    * 1. Retrieve partial address suggestions via `/autocomplete/addresses`
-   * 2. Retrieve the entire address by following the URL provided by the suggestion
+   * 2. Retrieve the entire address with the ID provided in the suggestion
    *
    * Step 2 will decrement your lookup balance.
    *
@@ -2309,30 +2281,27 @@ export interface operations {
    *
    * ## Filters
    *
-   * You can strictly narrow your result by adding filters to your querystring which correspond with an address attribute.
-   *
-   * For instance, you can restrict to postcode `SW1A 2AA` by appending `postcode=sw1a2aa`.
+   * You can strictly narrow your result by adding filters to your querystring. For instance, you can restrict to postcode `SW1A 2AA` by appending `postcode=sw1a2aa`.
    *
    * If a filter term is invalid, e.g. `postcode=SW1A2AAA`, then an empty result set is returned and no lookup is incurred.
    *
-   * You can also scope using multiple terms for the same filter with a comma separated list of terms. E.g. Restrict results to E1, E2 and E3 outward codes: `postcode_outward=e1,e2,e3`. Multiple terms are <code>OR</code>'ed, i.e. the matching result sets are combined.
+   * You can also scope using multiple terms for the same filter with a comma separated list of terms. E.g. Restrict results to E1, E2 and E3 outward codes: `postcode_outward=e1,e2,e3`. Multiple terms are `OR`'ed, i.e. the matching result sets are combined.
    *
    * All filters can accept multiple terms unless stated otherwise below.
    *
-   * Multiple filters can also be combined. E.g. Restrict results to small user organisations in the N postcode area: `su_organisation_indicator=Y&postcode_area=n`. Multiple filters are <code>AND</code>'ed, i.e. each additional filter narrows the result set.
+   * Filters can also be combined. E.g. Restrict results to small user organisations in the N postcode area: `su_organisation_indicator=Y&postcode_area=n`. Multiple filters are `AND`'ed, i.e. each additional filter narrows the result set.
    *
    * A maximum of **10** terms are allowed across all filters.
    *
    * ## Biases
    *
-   * You can boost certain addresses results that correspond with a certain address attribute. All bias searches are prefixed with `bias_`.
+   * You can boost certain addresses results that match specific address criteria. All bias searches are prefixed with `bias_`.
    *
-   * Biased searches, unlike filtered searches, also allow unmatched addresses to appear. These will rank lower.
+   * Biasing (unlike filtering) also allow unmatched addresses to appear with lower precedence.
    *
    * For instance, can boost addresses with postcode areas `SW` and `SE` by appending `bias_postcode_area=SW,SE`.
    *
-   * No bias effect applies to bias terms that are invalid.
-   * e.g. `bias_postcode=SW1A2AAA`
+   * No bias effect applies to bias terms that are invalid. e.g. `bias_postcode=SW1A2AAA`
    *
    * You may scope using multiple terms for the same bias with a comma separated list of terms. E.g. Restrict results to `E1`, `E2` and `E3` outward codes: <code>bias_postcode_outward=e1,e2,e3</code>.
    *
@@ -2363,7 +2332,7 @@ export interface operations {
   AddressAutocomplete: {
     parameters: {
       query: {
-        api_key: components["schemas"]["ApiKeyParam"];
+        api_key?: components["schemas"]["ApiKeyParam"];
         /** Specifies the address you wish to query. Query can be shortened to `q=` */
         query?: string;
         context?: components["schemas"]["Context"];
@@ -2419,7 +2388,7 @@ export interface operations {
         address: string;
       };
       query: {
-        api_key: components["schemas"]["ApiKeyParam"];
+        api_key?: components["schemas"]["ApiKeyParam"];
       };
     };
     responses: {
@@ -2449,7 +2418,7 @@ export interface operations {
         address: string;
       };
       query: {
-        api_key: components["schemas"]["ApiKeyParam"];
+        api_key?: components["schemas"]["ApiKeyParam"];
       };
     };
     responses: {
@@ -2574,7 +2543,7 @@ export interface operations {
       query: {
         /** Specify ID of the licensee after which you would like to list results */
         starting_after?: number;
-        user_token: components["schemas"]["UserTokenParam"];
+        user_token?: components["schemas"]["UserTokenParam"];
         /** Specify the maximum number of results to return per page. Default and maximum is `100`. */
         limit?: components["schemas"]["LimitParam"];
         /** Filter result by licensee name. Query can be shortened to `q=` */
@@ -2597,7 +2566,7 @@ export interface operations {
         key: components["schemas"]["ApiKeyParam"];
       };
       query: {
-        user_token: components["schemas"]["UserTokenParam"];
+        user_token?: components["schemas"]["UserTokenParam"];
       };
     };
     responses: {
@@ -2622,7 +2591,7 @@ export interface operations {
         licensee: components["schemas"]["LicenseeParam"];
       };
       query: {
-        user_token: components["schemas"]["UserTokenParam"];
+        user_token?: components["schemas"]["UserTokenParam"];
       };
     };
     responses: {
@@ -2642,7 +2611,7 @@ export interface operations {
         licensee: components["schemas"]["LicenseeParam"];
       };
       query: {
-        user_token: components["schemas"]["UserTokenParam"];
+        user_token?: components["schemas"]["UserTokenParam"];
       };
     };
     responses: {
@@ -2667,7 +2636,7 @@ export interface operations {
         licensee: components["schemas"]["LicenseeParam"];
       };
       query: {
-        user_token: components["schemas"]["UserTokenParam"];
+        user_token?: components["schemas"]["UserTokenParam"];
       };
     };
     responses: {
@@ -2701,7 +2670,7 @@ export interface operations {
         key: components["schemas"]["ApiKeyParam"];
       };
       query: {
-        user_token: components["schemas"]["UserTokenParam"];
+        user_token?: components["schemas"]["UserTokenParam"];
       };
     };
     responses: {
@@ -2732,7 +2701,7 @@ export interface operations {
         key: components["schemas"]["ApiKeyParam"];
       };
       query: {
-        user_token: components["schemas"]["UserTokenParam"];
+        user_token?: components["schemas"]["UserTokenParam"];
       };
     };
     responses: {
@@ -2798,7 +2767,7 @@ export interface operations {
         config: components["schemas"]["ConfigParam"];
       };
       query: {
-        user_token: components["schemas"]["UserTokenParam"];
+        user_token?: components["schemas"]["UserTokenParam"];
       };
     };
     responses: {
@@ -2841,7 +2810,7 @@ export interface operations {
         config: components["schemas"]["ConfigParam"];
       };
       query: {
-        user_token: components["schemas"]["UserTokenParam"];
+        user_token?: components["schemas"]["UserTokenParam"];
       };
     };
     responses: {

--- a/openapi.ts
+++ b/openapi.ts
@@ -689,8 +689,24 @@ export interface components {
       /** @enum {string} */
       message: "Success";
     };
+    /**
+     * Context
+     * @description Limits search results within a geographical boundary or country.
+     * @enum {string}
+     */
+    Context: "GBR" | "USA";
+    /**
+     * No Context Provided
+     * @description Empty string if no context is provided or key check has failed
+     * @enum {string}
+     */
+    NoContext: "";
     /** Key */
     ApiKey: {
+      /** @description Returns current context if it is in the list of available contexts for this key. */
+      context:
+        | components["schemas"]["Context"]
+        | components["schemas"]["NoContext"];
       /**
        * @description Determines whether the key can be used by the requesting agent.
        *
@@ -919,12 +935,6 @@ export interface components {
       message: "Success";
     };
     /**
-     * Context
-     * @description Limits search results within a geographical boundary or country.
-     * @enum {string}
-     */
-    Context: "gbr" | "usa";
-    /**
      * Limit
      * Format: int32
      * @description Specifies the maximum number of suggestions to retrieve.
@@ -1120,6 +1130,16 @@ export interface components {
       dataset?: components["schemas"]["Dataset"];
     };
     /**
+     * PAF Alias Address
+     * @description PAF Aliases addresses are alternate ways to present an address already found on PAF.
+     *
+     * Alias data is information the public chooses to use when addressing mail, but which isn’t actually required for delivery purposes.  The Alias data contains records of alternative address details that are included in the address but not necessarily needed for delivery purposes.
+     */
+    PafAliasAddress: components["schemas"]["PafAddress"] & {
+      /** @enum {undefined} */
+      dataset?: components["schemas"]["Dataset"];
+    };
+    /**
      * Global Address
      * @description Global (non-UK) address in the UK address format
      */
@@ -1234,6 +1254,7 @@ export interface components {
         | components["schemas"]["PafAddress"]
         | components["schemas"]["MrAddress"]
         | components["schemas"]["WelshPafAddress"]
+        | components["schemas"]["PafAliasAddress"]
         | components["schemas"]["NybAddress"]
         | components["schemas"]["GbrGlobalAddress"];
     };
@@ -1732,6 +1753,7 @@ export interface components {
           | components["schemas"]["MrAddress"]
           | components["schemas"]["NybAddress"]
           | components["schemas"]["WelshPafAddress"]
+          | components["schemas"]["PafAliasAddress"]
         )[];
         /** Format: int32 */
         total: number;

--- a/openapi.ts
+++ b/openapi.ts
@@ -233,6 +233,10 @@ export interface paths {
      *
      * For address autocomplete, see our address finder API - which is designed for speed and address completion.
      *
+     * ## Reverse Geocoding
+     *
+     * Return a list of addresses around a point using the lon= and lat= querystring arguments. Addresses will be sorted in order of distance to the point. The search radius is 100m.
+     *
      * ## Filters
      *
      * You can strictly narrow your result by adding filters to your query string which correspond with an address attribute.
@@ -1737,6 +1741,26 @@ export interface components {
         | components["schemas"]["UspsAddress"]
         | components["schemas"]["UsaGlobalAddress"];
     };
+    /**
+     * Longitude
+     * Format: float
+     * @description Longitude query for reverse geocoding.
+     *
+     * An accompanying latitude (lat=) query must be submitted for a valid reverse geocode query.
+     *
+     * @example -0.12767
+     */
+    AddressLongitudeParam: number;
+    /**
+     * Latitude
+     * Format: float
+     * @description Latitude query for reverse geocoding.
+     *
+     * An accompanying longitude (lon=) query must be submitted for a valid reverse geocode query.
+     *
+     * @example 51.503541
+     */
+    AddressLatitudeParam: number;
     /** Address Search Response */
     AddressResponse: {
       /**
@@ -2467,6 +2491,10 @@ export interface operations {
    *
    * For address autocomplete, see our address finder API - which is designed for speed and address completion.
    *
+   * ## Reverse Geocoding
+   *
+   * Return a list of addresses around a point using the lon= and lat= querystring arguments. Addresses will be sorted in order of distance to the point. The search radius is 100m.
+   *
    * ## Filters
    *
    * You can strictly narrow your result by adding filters to your query string which correspond with an address attribute.
@@ -2527,6 +2555,8 @@ export interface operations {
         limit?: components["schemas"]["LimitParam"];
         page?: components["schemas"]["PageParam"];
         filter?: components["schemas"]["FilterParam"];
+        lon?: components["schemas"]["AddressLongitudeParam"];
+        lat?: components["schemas"]["AddressLatitudeParam"];
         postcode_outward?: components["schemas"]["PostcodeOutwardParam"];
         postcode?: components["schemas"]["PostcodeParam"];
         postcode_area?: components["schemas"]["PostcodeAreaParam"];

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@ideal-postcodes/openapi",
-  "version": "3.0.0-beta.2",
+  "version": "3.0.0-beta.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@ideal-postcodes/openapi",
-  "version": "3.0.0-beta.1",
+  "version": "3.0.0-beta.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@ideal-postcodes/openapi",
-  "version": "2.1.1",
+  "version": "3.0.0-beta.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@ideal-postcodes/openapi",
   "description": "Ideal Postcodes OpenAPI v3 specifications",
-  "version": "2.1.1",
+  "version": "3.0.0-beta.1",
   "devDependencies": {
     "@cablanchard/semantic-release": "~1.3.4",
     "@cablanchard/tsconfig": "~2.0.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@ideal-postcodes/openapi",
   "description": "Ideal Postcodes OpenAPI v3 specifications",
-  "version": "3.0.0-beta.2",
+  "version": "3.0.0-beta.3",
   "devDependencies": {
     "@cablanchard/semantic-release": "~1.3.4",
     "@cablanchard/tsconfig": "~2.0.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@ideal-postcodes/openapi",
   "description": "Ideal Postcodes OpenAPI v3 specifications",
-  "version": "3.0.0-beta.1",
+  "version": "3.0.0-beta.2",
   "devDependencies": {
     "@cablanchard/semantic-release": "~1.3.4",
     "@cablanchard/tsconfig": "~2.0.0",


### PR DESCRIPTION
- Merged UK Address Suggestion format
- IDEALPOSTCODES prefix in authorisation header is now optional
- Reorganised documentation
- Fix Address Suggestion url object
- Drop requirement for api_key or user_token in querystring as these may
  also be provided in authorisation header
- Relax type requirements on fields which can be a number or empty
  string (number|""). These are now reported as (number|string).
- Fixed typos

BREAKING CHANGE:

- UK Address Suggestion formats for PAF, MR, NYB and PAFW have been
  merged into one suggestion type for the UK
- Rename GlobalAddressSuggestion to AddressSuggestion