### PR TITLE
chore: migrate to pnpm and upgrade to node 24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,25 +9,23 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Use Node.js 20
-        uses: actions/setup-node@v3
-        with:
-          node-version: 20.x
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
 
-      - name: Cache node modules
-        uses: actions/cache@v3
+      - name: Use Node.js 20
+        uses: actions/setup-node@v4
         with:
-          path: ~/.npm
-          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+          node-version: 24.x
+          cache: pnpm
 
       - name: Install
-        run: npm install
+        run: pnpm install --frozen-lockfile
 
       - name: Lint spec
-        run: npm run test
+        run: pnpm test
 
       - name: Build
-        run: npm run build
+        run: pnpm build
 
       - name: Smoke test
         run: node smoke.js

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: 24
           cache: pnpm
           registry-url: https://registry.npmjs.org
 

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "prepublish": "tsc",
     "semantic-release": "semantic-release",
     "start": "redocly preview --project-dir dist",
-    "mock": "npm run build && prism mock ./dist/openapi.yaml",
+    "mock": "pnpm build && prism mock ./dist/openapi.yaml",
     "build": "tsc",
     "test": "redocly lint dist/openapi.yaml && redocly lint dist/openapi.json"
   },

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@ideal-postcodes/openapi",
   "description": "Ideal Postcodes OpenAPI v3 specifications",
   "version": "4.16.0",
-  "packageManager": "pnpm@10.28.0",
+  "packageManager": "pnpm@10.33.0",
   "devDependencies": {
     "@cablanchard/tsconfig": "~2.0.0",
     "@redocly/cli": "~2.0.7",


### PR DESCRIPTION
## Summary
- Migrate CI workflow from npm to pnpm with automated caching
- Upgrade CI and release workflows to Node.js 24
- Bump pnpm to latest version (10.33.0)
- Update mock script to use pnpm

## Test plan
- [ ] CI workflow passes with pnpm
- [ ] Release workflow passes with node 24
- [ ] Mock script works correctly